### PR TITLE
Don't throw stack traces when panes don't exist or nothing to move

### DIFF
--- a/lib/move-panes.coffee
+++ b/lib/move-panes.coffee
@@ -55,7 +55,7 @@ module.exports =
     position = axis.children.indexOf source
     target = position + delta
     return unless target < axis.children.length
-    return axis.children[target].getPanes()[0]
+    return axis.children[target].getPanes()[0] if axis.children[target]
 
   deactivate: ->
 

--- a/lib/move-panes.coffee
+++ b/lib/move-panes.coffee
@@ -45,7 +45,7 @@ module.exports =
     axis = pane.parent
     child = pane
     while true
-      return unless axis.constructor.name == 'PaneAxis'
+      return [] unless axis.constructor.name == 'PaneAxis'
       break if axis.orientation == orientation
       child = axis
       axis = axis.parent


### PR DESCRIPTION
Fixes #13 and #5. 

I got a bit tired of seeing those red stack traces when I accidentally tried to move to a non-existing pane, or tried moving when my focus was on an empty pane. This fixes those errors; it doesn't do anything else, however.

I've read the suggestions to open a new pane when moving to a non-existing pane, etc. but I don't have time for it at the moment. I might look into it later, but this fixes my current frustration. Thought I'd send a PR.
